### PR TITLE
change has_key deprecated function to in operator

### DIFF
--- a/kaldi/patch/steps/libs/nnet3/report/log_parse.py
+++ b/kaldi/patch/steps/libs/nnet3/report/log_parse.py
@@ -75,7 +75,7 @@ def fill_nonlin_stats_table_with_regex_result(groups, gate_index, stats_table):
     deriv_50th = float(deriv_percentiles_split[6])
     deriv_95th = float(deriv_percentiles_split[9])
     try:
-        if stats_table[component_name]['stats'].has_key(iteration):
+        if iteration in stats_table[component_name]['stats']:
             stats_table[component_name]['stats'][iteration].extend(
                     [value_mean, value_stddev,
                      deriv_mean, deriv_stddev,

--- a/kaldi/patch/steps/libs/nnet3/xconfig/parser.py
+++ b/kaldi/patch/steps/libs/nnet3/xconfig/parser.py
@@ -84,7 +84,7 @@ def xconfig_line_to_object(config_line, prev_layers = None):
         if x is None:
             return None
         (first_token, key_to_value) = x
-        if not config_to_layer.has_key(first_token):
+        if first_token not in config_to_layer:
             raise RuntimeError("No such layer type '{0}'".format(first_token))
         return config_to_layer[first_token](first_token, key_to_value, prev_layers)
     except Exception:

--- a/kaldi/patch/steps/nnet3/dot/nnet3_to_dot.py
+++ b/kaldi/patch/steps/nnet3/dot/nnet3_to_dot.py
@@ -122,9 +122,9 @@ def ProcessAppendDescriptor(segment, parent_node_name, affix, edge_attributes = 
 
     attr_string = ''
     if edge_attributes is not None:
-        if edge_attributes.has_key('label'):
+        if 'label' in edge_attributes:
             attr_string += " label={0} ".format(edge_attributes['label'])
-        if edge_attributes.has_key('style'):
+        if 'style' in edge_attributes:
             attr_string += ' style={0} '.format(edge_attributes['style'])
 
     dot_string = '{0} -> {1} [tailport=s]'.format(GetDotNodeName(desc_name)['node'], GetDotNodeName(parent_node_name)['node'])
@@ -142,10 +142,10 @@ def ProcessRoundDescriptor(segment, parent_node_name, affix, edge_attributes = N
     label = 'Round ({0})'.format(segment['arguments'][1])
     style = None
     if edge_attributes is not None:
-        if edge_attributes.has_key('label'):
+        if 'label' in edge_attributes:
             label = "{0} {1}".format(edge_attributes['label'], label)
-        if edge_attributes.has_key('style'):
-            style  = 'style={0}'.format(edge_attributes['style'])
+        if 'style' in edge_attributes:
+            style = 'style={0}'.format(edge_attributes['style'])
 
     attr_string = 'label="{0}"'.format(label)
     if style is not None:
@@ -164,10 +164,10 @@ def ProcessOffsetDescriptor(segment, parent_node_name, affix, edge_attributes = 
     label = 'Offset ({0})'.format(segment['arguments'][1])
     style = None
     if edge_attributes is not None:
-        if edge_attributes.has_key('label'):
+        if 'label' in edge_attributes:
             label = "{0} {1}".format(edge_attributes['label'], label)
-        if edge_attributes.has_key('style'):
-            style  = 'style={0}'.format(edge_attributes['style'])
+        if 'style' in edge_attributes:
+            style = 'style={0}'.format(edge_attributes['style'])
 
     attr_string = 'label="{0}"'.format(label)
     if style is not None:
@@ -204,9 +204,9 @@ def ProcessSumDescriptor(segment, parent_node_name, affix, edge_attributes = Non
 
     attr_string = ''
     if edge_attributes is not None:
-        if edge_attributes.has_key('label'):
+        if 'label' in edge_attributes:
             attr_string += " label={0} ".format(edge_attributes['label'])
-        if edge_attributes.has_key('style'):
+        if 'style' in edge_attributes:
             attr_string += ' style={0} '.format(edge_attributes['style'])
 
     dot_string = '{0} -> {1}'.format(GetDotNodeName(desc_name)['node'], GetDotNodeName(parent_node_name)['node'])
@@ -221,10 +221,10 @@ def ProcessReplaceIndexDescriptor(segment, parent_node_name, affix, edge_attribu
     label = 'ReplaceIndex({0}, {1})'.format(segment['arguments'][1], segment['arguments'][2])
     style = None
     if edge_attributes is not None:
-        if edge_attributes.has_key('label'):
+        if 'label' in edge_attributes:
             label = "{0} {1}".format(edge_attributes['label'], label)
-        if edge_attributes.has_key('style'):
-            style  = 'style={0}'.format(edge_attributes['style'])
+        if 'style' in edge_attributes:
+            style = 'style={0}'.format(edge_attributes['style'])
 
     attr_string = 'label="{0}"'.format(label)
     if style is not None:

--- a/kaldi/steps_multitask/libs/nnet3/report/log_parse.py
+++ b/kaldi/steps_multitask/libs/nnet3/report/log_parse.py
@@ -75,7 +75,7 @@ def fill_nonlin_stats_table_with_regex_result(groups, gate_index, stats_table):
     deriv_50th = float(deriv_percentiles_split[6])
     deriv_95th = float(deriv_percentiles_split[9])
     try:
-        if stats_table[component_name]['stats'].has_key(iteration):
+        if iteration in stats_table[component_name]['stats']:
             stats_table[component_name]['stats'][iteration].extend(
                     [value_mean, value_stddev,
                      deriv_mean, deriv_stddev,

--- a/kaldi/steps_multitask/libs/nnet3/xconfig/parser.py
+++ b/kaldi/steps_multitask/libs/nnet3/xconfig/parser.py
@@ -84,7 +84,7 @@ def xconfig_line_to_object(config_line, prev_layers = None):
         if x is None:
             return None
         (first_token, key_to_value) = x
-        if not config_to_layer.has_key(first_token):
+        if first_token not in config_to_layer:
             raise RuntimeError("No such layer type '{0}'".format(first_token))
         return config_to_layer[first_token](first_token, key_to_value, prev_layers)
     except Exception:

--- a/kaldi/steps_multitask/nnet3/dot/nnet3_to_dot.py
+++ b/kaldi/steps_multitask/nnet3/dot/nnet3_to_dot.py
@@ -122,9 +122,9 @@ def ProcessAppendDescriptor(segment, parent_node_name, affix, edge_attributes = 
 
     attr_string = ''
     if edge_attributes is not None:
-        if edge_attributes.has_key('label'):
+        if 'label' in edge_attributes:
             attr_string += " label={0} ".format(edge_attributes['label'])
-        if edge_attributes.has_key('style'):
+        if 'style' in edge_attributes:
             attr_string += ' style={0} '.format(edge_attributes['style'])
 
     dot_string = '{0} -> {1} [tailport=s]'.format(GetDotNodeName(desc_name)['node'], GetDotNodeName(parent_node_name)['node'])
@@ -142,10 +142,10 @@ def ProcessRoundDescriptor(segment, parent_node_name, affix, edge_attributes = N
     label = 'Round ({0})'.format(segment['arguments'][1])
     style = None
     if edge_attributes is not None:
-        if edge_attributes.has_key('label'):
+        if 'label' in  edge_attributes:
             label = "{0} {1}".format(edge_attributes['label'], label)
-        if edge_attributes.has_key('style'):
-            style  = 'style={0}'.format(edge_attributes['style'])
+        if 'style' in  edge_attributes:
+            style = 'style={0}'.format(edge_attributes['style'])
 
     attr_string = 'label="{0}"'.format(label)
     if style is not None:
@@ -164,10 +164,10 @@ def ProcessOffsetDescriptor(segment, parent_node_name, affix, edge_attributes = 
     label = 'Offset ({0})'.format(segment['arguments'][1])
     style = None
     if edge_attributes is not None:
-        if edge_attributes.has_key('label'):
+        if 'label' in  edge_attributes:
             label = "{0} {1}".format(edge_attributes['label'], label)
-        if edge_attributes.has_key('style'):
-            style  = 'style={0}'.format(edge_attributes['style'])
+        if 'style' in edge_attributes:
+            style = 'style={0}'.format(edge_attributes['style'])
 
     attr_string = 'label="{0}"'.format(label)
     if style is not None:
@@ -204,9 +204,9 @@ def ProcessSumDescriptor(segment, parent_node_name, affix, edge_attributes = Non
 
     attr_string = ''
     if edge_attributes is not None:
-        if edge_attributes.has_key('label'):
+        if 'label' in  edge_attributes:
             attr_string += " label={0} ".format(edge_attributes['label'])
-        if edge_attributes.has_key('style'):
+        if 'style' in  edge_attributes:
             attr_string += ' style={0} '.format(edge_attributes['style'])
 
     dot_string = '{0} -> {1}'.format(GetDotNodeName(desc_name)['node'], GetDotNodeName(parent_node_name)['node'])
@@ -221,9 +221,9 @@ def ProcessReplaceIndexDescriptor(segment, parent_node_name, affix, edge_attribu
     label = 'ReplaceIndex({0}, {1})'.format(segment['arguments'][1], segment['arguments'][2])
     style = None
     if edge_attributes is not None:
-        if edge_attributes.has_key('label'):
+        if 'label' in  edge_attributes:
             label = "{0} {1}".format(edge_attributes['label'], label)
-        if edge_attributes.has_key('style'):
+        if 'style' in  edge_attributes:
             style  = 'style={0}'.format(edge_attributes['style'])
 
     attr_string = 'label="{0}"'.format(label)


### PR DESCRIPTION
`dict.has_key('key')` is deprecated in favour of `in` operator. This pull request changes those instances.